### PR TITLE
Update docker-compose.yml

### DIFF
--- a/hw-17/docker-compose.yml
+++ b/hw-17/docker-compose.yml
@@ -5,7 +5,9 @@ services:
     volumes:
       - post_db:/data/db
     networks:
-      - reddit
+      reddit:
+        aliases:
+        - comment_db
   ui:
     build: ./ui
     image: ${USERNAME}/ui:1.0


### PR DESCRIPTION
Service mongo must have 2 network aliases. The one is used by service name, and another (comment_db) should be added.
Если это не ошибка а повод для размышления - то можно не добавлять)