### PR TITLE
Update docker-compose-logging1.yml

### DIFF
--- a/hw-25/docker-compose-logging1.yml
+++ b/hw-25/docker-compose-logging1.yml
@@ -7,13 +7,13 @@ services:
       - "24224:24224/udp"
 
   elasticsearch:
-    image: elasticsearch
+    image: elasticsearch:7.4.0
     expose:
       - 9200
     ports:
       - "9200:9200"
 
   kibana:
-    image: kibana
+    image: kibana:7.4.0
     ports:
       - "5601:5601"


### PR DESCRIPTION
According to dockerhub The latest tag is not supported. For example taken latest at this moment 7.4.0