### PR TITLE
Update gitlab-ci-1.yml

### DIFF
--- a/kubernetes-4/ui/gitlab-ci-1.yml
+++ b/kubernetes-4/ui/gitlab-ci-1.yml
@@ -34,6 +34,8 @@ release:
   script:
     - setup_docker
     - release
+  variables:
+    DOCKER_TLS_CERTDIR: ""
   only:
     - master
 


### PR DESCRIPTION
Without empty variable DOCKER_TLS_CERTDIR stage release ends with error